### PR TITLE
Remove request forgery cookie on logout

### DIFF
--- a/src/Alloy.Mvc.Template/Controllers/PageControllerBase.cs
+++ b/src/Alloy.Mvc.Template/Controllers/PageControllerBase.cs
@@ -1,9 +1,10 @@
-﻿using System.Web.Mvc;
+using System.Web.Mvc;
 using AlloyTemplates.Business;
 using AlloyTemplates.Models.Pages;
 using AlloyTemplates.Models.ViewModels;
 using EPiServer.Web.Mvc;
 using EPiServer.Shell.Security;
+using EPiServer.Framework.Web;
 
 namespace AlloyTemplates.Controllers
 {
@@ -29,6 +30,11 @@ namespace AlloyTemplates.Controllers
         public ActionResult Logout()
         {
             UISignInManager.Service.SignOut();
+            new AspNetAntiForgery(
+                    ControllerContext.RequestContext.HttpContext.Request,
+                    ControllerContext.RequestContext.HttpContext.Response)
+                .RemoveCookie();
+
             return RedirectToAction("Index");
         }
 

--- a/src/Alloy.Mvc.Template/Properties/AssemblyInfo.cs
+++ b/src/Alloy.Mvc.Template/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 
 
 [assembly: CLSCompliant(false)]
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyInformationalVersion("1.1.0-developerbuild")]
+[assembly: AssemblyVersion("1.1.1")]
+[assembly: AssemblyInformationalVersion("1.1.1-developerbuild")]


### PR DESCRIPTION
The request forgery cookie is added when logging in and we need to
remove it to not get a request forgery exception the next time a user
logs in.